### PR TITLE
swap plot axes for non-square fits files

### DIFF
--- a/astride/detect.py
+++ b/astride/detect.py
@@ -259,7 +259,7 @@ class Streak:
 
         pl.xlabel('X/pixel')
         pl.ylabel('Y/pixel')
-        pl.axis([0, self.image.shape[0], 0, self.image.shape[1]])
+        pl.axis([0, self.image.shape[1], 0, self.image.shape[0]])
         pl.savefig('%sall.png' % self.output_path)
 
         # Plot all individual edges (connected).


### PR DESCRIPTION
looks like my issue was a small one. this will fix the all.png for non-sq. fits files